### PR TITLE
Feature/crosstalk (WIP)

### DIFF
--- a/R/timevis.R
+++ b/R/timevis.R
@@ -269,10 +269,25 @@
 timevis <- function(data, groups, showZoom = TRUE, zoomFactor = 0.5, fit = TRUE,
                     options, width = NULL, height = NULL, elementId = NULL) {
 
+
+
   # Validate the input data
   if (missing(data)) {
     data <- data.frame()
   }
+
+  # handle crosstalk
+  crosstalkOpts <- NULL
+  if(inherits(data,"SharedData")) {
+    # collect key and group
+    crosstalkOpts <- list(
+      key = data$key(),
+      group = data$groupName()
+    )
+    # get data from SharedData
+    data <- data$data(withKey = TRUE)
+  }
+
   if (!is.data.frame(data)) {
     stop("timevis: 'data' must be a data.frame",
          call. = FALSE)
@@ -338,6 +353,12 @@ timevis <- function(data, groups, showZoom = TRUE, zoomFactor = 0.5, fit = TRUE,
     rmarkdown::html_dependency_jquery(),
     rmarkdown::html_dependency_bootstrap("default")
   )
+
+  # add crosstalk deps and options
+  if(!is.null(crosstalkOpts)) {
+    deps <- c(deps, crosstalk::crosstalkLibs())
+    x$crosstalkOpts = crosstalkOpts
+  }
 
   # create widget
   htmlwidgets::createWidget(

--- a/R/timevis.R
+++ b/R/timevis.R
@@ -281,7 +281,8 @@ timevis <- function(data, groups, showZoom = TRUE, zoomFactor = 0.5, fit = TRUE,
   if(inherits(data,"SharedData")) {
     # collect key and group
     crosstalkOpts <- list(
-      key = data$key(),
+      # ideally key will match id, but we can't be sure
+      key = data$data(withKey = TRUE)[,c("id", "key_")],
       group = data$groupName()
     )
     # get data from SharedData

--- a/inst/example/crosstalk.R
+++ b/inst/example/crosstalk.R
@@ -7,7 +7,82 @@ sd <- SharedData$new(
     id = 1:2,
     content = c("one", "two"),
     start = c("2016-01-10", "2016-01-12")
+  ),
+  group = "mygroup"
+)
+
+tv <- timevis(sd, showZoom = FALSE)
+
+# prove crosstalk and timevis are now friends
+###### control from the outside ####
+htmlwidgets::onRender(
+  tv,
+"
+// toggle selection between 1 and 2 every second
+//  in a very messy way
+function(el,x) {
+  var sel = new crosstalk.SelectionHandle('mygroup');
+  var toggler = ['1','2'];
+  var state = false;
+
+  sel.set(toggler[Number(state)]);
+  setInterval(
+    function() {
+      state = !state;
+      sel.set(toggler[Number(state)]);
+    },
+    1000
+  )
+}
+"
+)
+
+###### control from outside btn ####
+library(htmltools)
+
+browsable(
+  tagList(
+    tags$button(id="btn-select","Select 1",onclick="selectOne()"),
+    tags$button(id="btn-select","Clear Select",onclick="selectClear()"),
+    tv,
+    tags$script(
+      HTML(
+"
+var sel = new crosstalk.SelectionHandle('mygroup');
+function selectOne() {
+  sel.set('1');
+};
+function selectClear() {
+  sel.clear();
+};
+"
+      )
+    )
   )
 )
 
-timevis(sd)
+
+
+###### react to select from timevis ####
+# it seems select is causing crosstalk to fire change twice
+#  will need to explore
+#  for now will handle with very crude conditional
+library(htmltools)
+
+browsable(tagList(
+  tags$p('select an item to see an old-school alert'),
+  tv,
+  tags$script(HTML(
+"
+var sel = new crosstalk.SelectionHandle('mygroup');
+sel.on('change', function(val){
+  // why is change getting fired twice ????????
+  //  it seems like timeline is firing select twice
+  if(!val.oldValue || val.oldValue[0] !== val.value[0]){
+    alert('timevis selected ' + val.value.join(' '));
+  }
+});
+"
+  ))
+))
+

--- a/inst/example/crosstalk.R
+++ b/inst/example/crosstalk.R
@@ -1,0 +1,13 @@
+#devtools::install_github("rstudio/crosstalk")
+library(crosstalk)
+library(timevis)
+
+sd <- SharedData$new(
+  data.frame(
+    id = 1:2,
+    content = c("one", "two"),
+    start = c("2016-01-10", "2016-01-12")
+  )
+)
+
+timevis(sd)

--- a/inst/htmlwidgets/timevis.js
+++ b/inst/htmlwidgets/timevis.js
@@ -95,6 +95,47 @@ HTMLWidgets.widget({
           }
         }
 
+        // for now handle crosstalk separately from Shiny
+        //  but eventually integrate the two
+        if(typeof(crosstalk)!=="undefined" && opts.crosstalkOpts) {
+          // get selection handle with group provided by
+          //  SharedData in R
+          var ctSelect = new crosstalk.SelectionHandle(opts.crosstalkOpts.group);
+          // handle selection on timeline
+          timeline.on('select', function (properties) {
+            // find properties.items in data and return key
+            ctSelect.set(
+              timeline.itemsData.get()
+                .filter(function(d) {
+                  return properties.items.indexOf(d.id) >= 0;
+                })
+                .map(function(d){
+                  return d.key_;
+                })
+            );
+          });
+
+          // handle selection from outside this timeline
+          ctSelect.on("change", function(val){
+            if(val.sender !== ctSelect) {
+              var selection = ctSelect.value;
+              if(typeof(selection)!==undefined && selection !== null) {
+                selection = Array.isArray(selection) ? selection : [selection];
+                timeline.setSelection(
+                  // find the keys
+                  timeline.itemsData.get()
+                    .filter(function(d){
+                      return selection.indexOf(d.key_) >= 0;
+                    })
+                    .map(function(d){
+                      return d.id;
+                    })
+                );
+              }
+            }
+          });
+        }
+
         // set the data items and groups
         timeline.itemsData.clear();
         timeline.itemsData.add(opts.items);


### PR DESCRIPTION
This represents a first pass at integrating [`crosstalk`](https://github.com/rstudio/crosstalk) in `timevis`.  I classify as a WIP since crosstalk is unstable and also I'm not sure if this fits in future plans or adheres to your coding style.  For now, I tried to code such that we can avoid hard dependency on `crosstalk` in the `DESCRIPTION`.

### [examples](https://github.com/timelyportfolio/timevis/blob/feature/crosstalk/inst/example/crosstalk.R)

### to do

- [ ] add an example with another `htmlwidget`
- [ ] decide how to handle added or deleted items, since they will currently require a `key_`.  Also, `SharedData` on the R side will not know what to do with these changes.
- [ ] add a Shiny example using `SharedData` instead of the traditional Shiny event handling
- [ ] figure out why the `select` event gets fired twice in `timevis`.  I did not have time to explore cause.
