### PR TITLE
Url Update for "official Timeline documentation"

### DIFF
--- a/man/timevis.Rd
+++ b/man/timevis.Rd
@@ -36,7 +36,7 @@ current date.}
 
 \item{options}{A named list containing any extra configuration options to
 customize the timeline. All available options can be found in the
-\href{http://visjs.org/docs/timeline/#Configuration_Options}{official
+\href{https://visjs.github.io/vis-timeline/docs/timeline/#Configuration_Options}{official
 Timeline documentation}. Note that any options that define a JavaScript
 function must be wrapped in a call to \code{htmlwidgets::JS()}. See the
 examples section below to see example usage.}


### PR DESCRIPTION
Seems that the current link is broken. The new link should be: "https://visjs.github.io/vis-timeline/docs/timeline/#Configuration_Options"