### PR TITLE
Updates broken official documentation link

### DIFF
--- a/R/timevis.R
+++ b/R/timevis.R
@@ -31,7 +31,7 @@
 #' current date.
 #' @param options A named list containing any extra configuration options to
 #' customize the timeline. All available options can be found in the
-#' \href{http://visjs.org/docs/timeline/#Configuration_Options}{official
+#' \href{https://visjs.github.io/vis-timeline/docs/timeline/#Configuration_Options}{official
 #' Timeline documentation}. Note that any options that define a JavaScript
 #' function must be wrapped in a call to \code{htmlwidgets::JS()}. See the
 #' examples section below to see example usage.


### PR DESCRIPTION
`timevis()` help points to an outdated link. I have updated the new location.