### PR TITLE
Avoid converting logical vectors to character

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -24,7 +24,13 @@ dataframeToD3 <- function(df) {
   row.names(df) <- NULL
   lapply(seq_len(nrow(df)), function(row) {
     row <- df[row, , drop = FALSE]
-    lapply(row[, !is.na(row), drop = FALSE], as.character)
+    lapply(row[, !is.na(row), drop = FALSE], function(x) {
+      if (!is.logical(x)) {
+        as.character(x)
+      } else {
+        x
+      }
+    })
   })
 }
 


### PR DESCRIPTION
This fix allows specifying `subgroupStack = TRUE` or `subgroupStack = list(subgroup_id = TRUE)` in the groups data.frame.

Current behaviour converts `subgroupStack = "TRUE"` to `{subgroupStack: {0: "T", 1: "R", 2: "U", 3: "E"}}`