### PR TITLE
Add Reset button to restore inital timeline view

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -635,3 +635,39 @@ zoomOut <- function(id, percent = 0.5, animation = TRUE) {
   method <- "zoomOut"
   callJS()
 }
+
+#' Reset the timeline to its initial view
+#'
+#' Restores the timeline window to the state it was in when first rendered,
+#' useful after zooming or panning.
+#'
+#' @param id Timeline id or a \code{timevis} object (the output from \code{timevis()})
+#' @param animation Whether or not to animate the reset.
+#' @examples
+#' \dontrun{
+#' timevis() %>%
+#'   resetTimevis()
+#' }
+#'
+#' if (interactive()) {
+# library(shiny)
+# shinyApp(
+#   ui = fluidPage(
+#     timevisOutput("timeline"),
+#     actionButton("btn", "Reset to initial view")
+#   ),
+#   server = function(input, output) {
+#     output$timeline <- renderTimevis(
+#       timevis()
+#     )
+#     observeEvent(input$btn, {
+#       resetTimevis("timeline")
+#     })
+#   }
+# )
+#' }
+#' @export
+resetTimevis <- function(id, animation = TRUE) {
+  method <- "resetTimevis"
+  callJS()
+}

--- a/R/api.R
+++ b/R/api.R
@@ -650,21 +650,21 @@ zoomOut <- function(id, percent = 0.5, animation = TRUE) {
 #' }
 #'
 #' if (interactive()) {
-# library(shiny)
-# shinyApp(
-#   ui = fluidPage(
-#     timevisOutput("timeline"),
-#     actionButton("btn", "Reset to initial view")
-#   ),
-#   server = function(input, output) {
-#     output$timeline <- renderTimevis(
-#       timevis()
-#     )
-#     observeEvent(input$btn, {
-#       resetTimevis("timeline")
-#     })
-#   }
-# )
+#' library(shiny)
+#' shinyApp(
+#'   ui = fluidPage(
+#'     timevisOutput("timeline"),
+#'     actionButton("btn", "Reset to initial view")
+#'   ),
+#'   server = function(input, output) {
+#'     output$timeline <- renderTimevis(
+#'       timevis()
+#'     )
+#'     observeEvent(input$btn, {
+#'       resetTimevis("timeline")
+#'     })
+#'   }
+#' )
 #' }
 #' @export
 resetTimevis <- function(id, animation = TRUE) {

--- a/R/timevis.R
+++ b/R/timevis.R
@@ -593,6 +593,12 @@ timevis_html <- function(id, style, class, ...){
         class = "btn btn-default btn-lg zoom-out",
         title = "Zoom out",
         "-"
+      ),
+      htmltools::tags$button(
+        type = "button",
+        class = "btn btn-default btn-lg zoom-reset saction-button",
+        title = "Reset to Initial View",
+        shiny::icon("fas fa-rotate-right")
       )
     )
   )

--- a/R/timevis.R
+++ b/R/timevis.R
@@ -596,9 +596,9 @@ timevis_html <- function(id, style, class, ...){
       ),
       htmltools::tags$button(
         type = "button",
-        class = "btn btn-default btn-lg zoom-reset saction-button",
+        class = "btn btn-default btn-lg zoom-reset",
         title = "Reset to Initial View",
-        shiny::icon("fas fa-rotate-right")
+        "↻"
       )
     )
   )

--- a/inst/htmlwidgets/timevis.js
+++ b/inst/htmlwidgets/timevis.js
@@ -166,14 +166,6 @@ HTMLWidgets.widget({
           timeline.fit({ animation : false });
         }
 
-        // Store the original window after fitting
-        if (originalWindow === null) {
-          originalWindow = {
-            start: timeline.getWindow().start,
-            end: timeline.getWindow().end
-          };
-        }
-
         // Show or hide the zoom button
         var zoomMenu = container.getElementsByClassName("zoom-menu")[0];
         if (opts.showZoom) {
@@ -186,14 +178,52 @@ HTMLWidgets.widget({
         // functions that the user wantd to run on the timeline before it was
         // ready
         var numApiCalls = opts['api'].length;
+
+        // Check if any API call will change the window
+        var hasWindowCall = false;
+        for (var i = 0; i < numApiCalls; i++) {
+          if (opts['api'][i].method === 'setWindow' ||
+              opts['api'][i].method === 'fitWindow' ||
+              opts['api'][i].method === 'centerTime') {
+            hasWindowCall = true;
+            break;
+          }
+        }
         for (var i = 0; i < numApiCalls; i++) {
           var call = opts['api'][i];
           var method = call.method;
           delete call['method'];
           try {
             that[method](call);
-          } catch(err) {}
+            } catch(err) {}
         }
+
+        // Store the original window after fitting
+        if (originalWindow === null) {
+        if (hasWindowCall) {
+          // Skip the first rangechanged (from fit)
+          var fired = false;
+          timeline.on('rangechanged', function captureWindow() {
+            if (!fired) {
+              fired = true;  // skip first fire (fit)
+              return;
+            }
+            originalWindow = {
+              start : timeline.getWindow().start,
+              end   : timeline.getWindow().end
+            };
+            timeline.off('rangechanged', captureWindow);  // remove listener
+          });
+        } else {
+          // No window API calls, just capture after fit
+          timeline.once('rangechanged', function() {
+            originalWindow = {
+              start : timeline.getWindow().start,
+              end   : timeline.getWindow().end
+            };
+          });
+        }
+      }
 
         // If crosstalk is enabled, respect its selection
         allItems = opts.items;
@@ -255,7 +285,6 @@ HTMLWidgets.widget({
           animation = true;
         }
         if (originalWindow === null) return;
-
         timeline.setWindow({
           start     : originalWindow.start,
           end       : originalWindow.end,
@@ -329,7 +358,7 @@ HTMLWidgets.widget({
       },
       zoomOut : function(params) {
         timeline.zoomOut(params.percent, { animation : params.animation });
-      },
+      }
     };
   }
 });
@@ -340,7 +369,7 @@ if (HTMLWidgets.shinyMode) {
     ['addItem', 'addItems', 'removeItem', 'addCustomTime', 'removeCustomTime',
      'fitWindow', 'centerTime', 'centerItem', 'setItems', 'setGroups',
      'setOptions', 'setSelection', 'setWindow', 'setCustomTime', 'setCurrentTime',
-     'zoomIn', 'zoomOut'];
+     'zoomIn', 'zoomOut', 'resetTimevis'];
 
   var addShinyHandler = function(fxn) {
     return function() {

--- a/inst/htmlwidgets/timevis.js
+++ b/inst/htmlwidgets/timevis.js
@@ -184,7 +184,8 @@ HTMLWidgets.widget({
         for (var i = 0; i < numApiCalls; i++) {
           if (opts['api'][i].method === 'setWindow' ||
               opts['api'][i].method === 'fitWindow' ||
-              opts['api'][i].method === 'centerTime') {
+              opts['api'][i].method === 'centerTime' ||
+              opts['api'][i].method === 'centerItem') {
             hasWindowCall = true;
             break;
           }

--- a/inst/htmlwidgets/timevis.js
+++ b/inst/htmlwidgets/timevis.js
@@ -19,6 +19,7 @@ HTMLWidgets.widget({
     var ctSel = null;
     var ctFil = null;
     var allItems;
+    var originalWindow = null;
 
     return {
 
@@ -38,6 +39,8 @@ HTMLWidgets.widget({
             .onclick = function(ev) { that.zoomInTimevis(opts.zoomFactor); };
           zoomMenu.getElementsByClassName("zoom-out")[0]
             .onclick = function(ev) { that.zoomOutTimevis(opts.zoomFactor); };
+          zoomMenu.getElementsByClassName("zoom-reset")[0]
+          .onclick = function(ev) { that.resetTimevis(); };
 
           // set listeners to events and pass data back to Shiny
           if (HTMLWidgets.shinyMode) {
@@ -163,6 +166,14 @@ HTMLWidgets.widget({
           timeline.fit({ animation : false });
         }
 
+        // Store the original window after fitting
+        if (originalWindow === null) {
+          originalWindow = {
+            start: timeline.getWindow().start,
+            end: timeline.getWindow().end
+          };
+        }
+
         // Show or hide the zoom button
         var zoomMenu = container.getElementsByClassName("zoom-menu")[0];
         if (opts.showZoom) {
@@ -236,6 +247,18 @@ HTMLWidgets.widget({
         timeline.setWindow({
           start   : newStart,
           end     : newEnd,
+          animation : animation
+        });
+      },
+      resetTimevis : function(animation) {
+        if (typeof animation === "undefined") {
+          animation = true;
+        }
+        if (originalWindow === null) return;
+
+        timeline.setWindow({
+          start     : originalWindow.start,
+          end       : originalWindow.end,
           animation : animation
         });
       },


### PR DESCRIPTION
## Problem
While using timevis in a project, we frequently needed to zoom in and out 
of the timeline using the mouse wheel to inspect specific time periods. 
However, getting back to the initial view was very difficult because:

- Mouse wheel zooming has no "snap back" to the original position
- The existing zoom in/out buttons are incremental and imprecise
- There was no way to restore the exact initial window that was set 
  when the timeline first loaded

This made the user experience frustrating, especially when working with 
timelines that span long time periods.

## Solution
Added a reset button to the zoom menu that restores the timeline to its 
exact initial view (the window state when the timeline first rendered).

Changes made:
- Added reset button (↺) to the zoom menu in `timevis_html()`
- Store the original window on first render in `renderValue()`
- Implement `resetTimevis()` in JS to restore the stored window

## Why this is useful
Anyone using timevis with large datasets or long time ranges will benefit 
from this — being able to freely explore the timeline by zooming and 
panning without worrying about losing the original view makes the widget 
much more user friendly.

## Testing
Tested in a Shiny app by:
1. Loading a timeline with a defined window
2. Zooming in/out using both mouse wheel and zoom buttons
3. Clicking reset — confirms it returns to the exact initial view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **“Reset to Initial View”** control next to the existing zoom buttons to restore the timeline’s initial visible window.

* **Bug Fixes**
  * Improved the accuracy of capturing and restoring the initial view bounds, including after programmatic updates.

* **Other**
  * Added a new programmatic API to trigger the reset (with optional animation), including support for invoking it from Shiny.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->